### PR TITLE
Scaffold plugin package

### DIFF
--- a/nerfacto_metric/__init__.py
+++ b/nerfacto_metric/__init__.py
@@ -1,0 +1,4 @@
+"""Plugin entry for nerfacto_metric."""
+from .model import get_trainer
+
+__all__ = ["get_trainer"]

--- a/nerfacto_metric/config.py
+++ b/nerfacto_metric/config.py
@@ -1,0 +1,4 @@
+"""Config placeholders for nerfacto_metric.
+
+We’ll add real configs (dataclasses / omegaconf nodes) in later steps.
+"""

--- a/nerfacto_metric/contrast.py
+++ b/nerfacto_metric/contrast.py
@@ -1,0 +1,1 @@
+"""Contrastive utilities for nerfacto_metric (to be implemented later)."""

--- a/nerfacto_metric/losses.py
+++ b/nerfacto_metric/losses.py
@@ -1,0 +1,1 @@
+"""Loss placeholders for nerfacto_metric (to be implemented later)."""

--- a/nerfacto_metric/model.py
+++ b/nerfacto_metric/model.py
@@ -1,0 +1,8 @@
+"""Model entry points for nerfacto_metric."""
+
+def get_trainer():
+    """Temporary placeholder that mimics returning a Nerfstudio Trainer.
+
+    Later we’ll construct and return a real Trainer that uses vanilla Nerfacto.
+    """
+    return "vanilla_nerfacto_trainer"

--- a/nerfacto_metric/priors.py
+++ b/nerfacto_metric/priors.py
@@ -1,0 +1,1 @@
+"""Prior modules for nerfacto_metric (to be implemented later)."""

--- a/scripts/run_ablation.sh
+++ b/scripts/run_ablation.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Placeholder; real ablation logic will be added later.
+echo "[run_ablation] not implemented yet"

--- a/scripts/smoke_train.py
+++ b/scripts/smoke_train.py
@@ -1,0 +1,8 @@
+"""Minimal smoke test: just checks that the plugin imports cleanly."""
+import importlib
+
+mod = importlib.import_module("nerfacto_metric")
+# touch the API so we fail early if it’s missing
+_ = mod.get_trainer()
+
+print("OK: plugin import")


### PR DESCRIPTION
### What
Scaffold `nerfacto_metric` plugin package and a smoke test script.

### Why
Create a minimal, importable plugin structure to build on.

### How
- Add package: nerfacto_metric/{__init__,config,model,losses,priors,contrast}.py
- `get_trainer()` placeholder returns a dummy handle.
- Add scripts/{smoke_train.py, run_ablation.sh}.

### Test Plan
- [x] PYTHONPATH=$PWD python scripts/smoke_train.py → prints "OK: plugin import"

### Notes
No functional changes to Nerfstudio yet; just scaffolding.
